### PR TITLE
imx51(gpu2d): offset the VG scissor by VGV1_TILEOFS

### DIFF
--- a/cerf/socs/imx51/imx51_gpu2d_vg_fill.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_vg_fill.cpp
@@ -98,21 +98,31 @@ void Imx51Gpu2dVgFill::Flush(const uint32_t (&regs)[0x100], bool bbox_live) {
     Gpu2dFillTarget t{};
     t.dest_pa   = regs[0x0];
     t.stride_px = (cfg0 & 0xFFFu) + 1u;
-    /* Clip = G2D_SCISSORX/Y (LEFT[10:0]/RIGHT[21:11]) intersect VGV1_SCISSORX/Y. */
+    /* sync_2 libOpenVG.dll 0x41C5B468 tile loop: VGV1_SCISSORX/Y (0x24/0x25) hold the
+       tile clamped in a grid anchored at 0, VGV1_TILEOFS (0x22) that tile's grid origin
+       plus the path-bbox sub-tile remainder, and G2D_SCISSORX/Y (0x8/0x9) the device
+       scissor - so device = grid + (TILEOFS - VGV1 near edge). */
     const uint32_t gsx = regs[0x8], gsy = regs[0x9];
     const uint32_t bsx = regs[0x24], bsy = regs[0x25];
-    t.clip_l = static_cast<int32_t>(std::max(gsx & 0x7FFu, bsx & 0x7FFu));
-    t.clip_r = static_cast<int32_t>(std::min((gsx >> 11) & 0x7FFu, (bsx >> 16) & 0x7FFu));
-    t.clip_t = static_cast<int32_t>(std::max(gsy & 0x7FFu, bsy & 0x7FFu));
-    t.clip_b = static_cast<int32_t>(std::min((gsy >> 11) & 0x7FFu, (bsy >> 16) & 0x7FFu));
-    /* The tile loops write BBOX as band/tile rect + guard margins folded into XFT,
-       so (bbox+XFT)*2^exp is absolute-device; a tighter bbox is unmodeled. */
+    const int32_t v_l = static_cast<int32_t>(bsx & 0x7FFu);
+    const int32_t v_t = static_cast<int32_t>(bsy & 0x7FFu);
+    const int32_t ox = static_cast<int32_t>(regs[0x22] & 0xFFFu) - v_l;
+    const int32_t oy = static_cast<int32_t>((regs[0x22] >> 12) & 0xFFFu) - v_t;
+    t.clip_l = std::max(static_cast<int32_t>(gsx & 0x7FFu), v_l + ox);
+    t.clip_r = std::min(static_cast<int32_t>((gsx >> 11) & 0x7FFu),
+                        static_cast<int32_t>((bsx >> 16) & 0x7FFu) + ox);
+    t.clip_t = std::max(static_cast<int32_t>(gsy & 0x7FFu), v_t + oy);
+    t.clip_b = std::min(static_cast<int32_t>((gsy >> 11) & 0x7FFu),
+                        static_cast<int32_t>((bsy >> 16) & 0x7FFu) + oy);
+    /* The tile loops write BBOX as band/tile rect + guard margins folded into XFT, so
+       (bbox+XFT)*2^exp is grid-space and takes the same ox/oy shift as the clip. */
     if (bbox_live) {
         const float ke = DeviceScale(regs);
-        if ((RegF(regs, 0x5A) + RegF(regs, 0x54)) * ke > static_cast<float>(t.clip_l) + 0.5f ||
-            (RegF(regs, 0x5C) + RegF(regs, 0x54)) * ke < static_cast<float>(t.clip_r) - 0.5f ||
-            (RegF(regs, 0x5B) + RegF(regs, 0x55)) * ke > static_cast<float>(t.clip_t) + 0.5f ||
-            (RegF(regs, 0x5D) + RegF(regs, 0x55)) * ke < static_cast<float>(t.clip_b) - 0.5f)
+        const float fx = static_cast<float>(ox), fy = static_cast<float>(oy);
+        if ((RegF(regs, 0x5A) + RegF(regs, 0x54)) * ke + fx > static_cast<float>(t.clip_l) + 0.5f ||
+            (RegF(regs, 0x5C) + RegF(regs, 0x54)) * ke + fx < static_cast<float>(t.clip_r) - 0.5f ||
+            (RegF(regs, 0x5B) + RegF(regs, 0x55)) * ke + fy > static_cast<float>(t.clip_t) + 0.5f ||
+            (RegF(regs, 0x5D) + RegF(regs, 0x55)) * ke + fy < static_cast<float>(t.clip_b) - 0.5f)
             Halt(regs, "VGV2 BBOX binds tighter than the scissor clip (not modeled)",
                  0x5Au, regs[0x5A]);
     }


### PR DESCRIPTION
The tile loop writes VGV1_SCISSORX/Y in a tile grid anchored at 0 and VGV1_TILEOFS as that tile's grid origin plus the path-bbox sub-tile remainder, while G2D_SCISSORX/Y is device-space. Intersecting the two directly clipped tiled fills short on the dirty-rect redraw path, dropping rows at tile boundaries: the splash wordmark flickered and home-screen buttons rendered cut off mid-element.

Shift the VGV1 edges by TILEOFS minus the scissor's own near edge, and apply the same shift to the VGV2 BBOX guard so both compare in one space.

Tested, with proof below:
<img width="800" height="1004" alt="pr_homescreen_before_after" src="https://github.com/user-attachments/assets/e67abb9e-2d3d-4fa0-87e8-4e9e50fad505" />
<img width="685" height="1000" alt="pr_splash_before_after" src="https://github.com/user-attachments/assets/12a03d04-2c2e-480a-bf1c-e87565432000" />
