### PR TITLE
 imx51(gpu2d): signed G2D stride, VG_BLEND_SRC image paint, INPUT=0x1B fills

### DIFF
--- a/cerf/socs/imx51/imx51_gpu2d_blend.h
+++ b/cerf/socs/imx51/imx51_gpu2d_blend.h
@@ -47,8 +47,7 @@ constexpr uint32_t PremultArgb(uint32_t argb) {
          | (Mul((argb >> 8) & 0xFFu, a) << 8) | Mul(argb & 0xFFu, a);
 }
 
-/* One un-premultiply channel divide (BLENDERCFG.OOALPHA result -> straight alpha);
-   the caller handles a==0 (a divide-by-zero on nonzero color is a corruption Halt). */
+/* One un-premultiply channel divide (BLENDERCFG.OOALPHA result -> straight alpha). */
 constexpr uint32_t UnpremultChannel(uint32_t ch, uint32_t a) {
     return (ch * 255u + a / 2u) / a > 255u ? 255u : (ch * 255u + a / 2u) / a;
 }

--- a/cerf/socs/imx51/imx51_gpu2d_command_engine.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_command_engine.cpp
@@ -268,11 +268,11 @@ void Imx51Gpu2dCommandEngine::StoreReg(uint32_t reg, uint32_t data) {
                mid-config with stale XY/WH); the fill itself fires at FLUSH. */
             if (vg_regs_[kAddrG2dInput] == 0x11u || vg_regs_[kAddrG2dInput] == 0x19u)
                 return;
-            /* INPUT 0x01 (COLOR, sub_41C6C6DC solid fill) and 0x09 (COLOR|COPYCOORD)
-               are rect fills. Under 0x09 with the GRADW paint engine (GRADIENT.ENABLE2)
-               + the blender enabled it is the multi-pass SRC_OVER image-paint composite
-               (sub_41C6338C); a flat vgClear/solid fill has neither. */
-            if (vg_regs_[kAddrG2dInput] == 0x01u || vg_regs_[kAddrG2dInput] == 0x09u) {
+            /* INPUT 0x01 (sub_41C6C6DC), 0x09 and 0x1B (libOpenVG.dll VA 0x41C718B8)
+               are rect fills; under 0x09 with GRADIENT.ENABLE2 + the blender enabled
+               it is the image-paint composite (sub_41C6338C) instead. */
+            if (vg_regs_[kAddrG2dInput] == 0x01u || vg_regs_[kAddrG2dInput] == 0x09u ||
+                vg_regs_[kAddrG2dInput] == 0x1Bu) {
                 if ((vg_regs_[0xD0] & 0x80u) && (vg_regs_[0x11] & (1u << 5))) {
                     emu_.Get<Imx51Gpu2dImagePaint>().Composite(vg_regs_);
                     return;

--- a/cerf/socs/imx51/imx51_gpu2d_direct2d.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_direct2d.cpp
@@ -6,6 +6,7 @@
 #include "../../boards/board_context.h"
 #include "../../cpu/emulated_memory.h"
 #include "imx51_gpu2d_rasterizer.h"
+#include "imx51_gpu2d_regfile.h"
 
 namespace {
 
@@ -49,7 +50,8 @@ void Imx51Gpu2dDirect2d::CheckCommonGates(const uint32_t (&regs)[0x100]) const {
     if (regs[0x10] != 0xFFFFFFu)  /* G2D_MASK identity wrap */
         Halt(regs, "direct-2D op MASK wrap (not modeled)", 0x10u, regs[0x10]);
     const uint32_t cfg0 = regs[0x1];
-    if (cfg0 >> 16)  /* TILED[16]/SRGB[17]/SWAP fields: linear, no swap - per-op FORMAT decode */
+    if (cfg0 & 0xFF7F0000u)  /* TILED[16]/SRGB[17]/SWAP fields: linear, no swap - per-op
+                                FORMAT decode; STRIDESIGN[23] is part of the stride */
         Halt(regs, "direct-2D op dest swap/tile/srgb (not modeled)", 0x1u, cfg0);
     if (regs[0x0] == 0u)
         Halt(regs, "direct-2D op dest BASE0 null bind", 0x0u, 0);
@@ -68,7 +70,7 @@ void Imx51Gpu2dDirect2d::Fill(const uint32_t (&regs)[0x100]) {
     const uint32_t xy = regs[kXy], wh = regs[kWh];
     Gpu2dFillTarget t{};
     t.dest_pa   = regs[0x0];
-    t.stride_px = (cfg0 & 0xFFFu) + 1u;
+    t.stride_dw = imx51_g2d_regfile::StrideWords(cfg0);
     t.dest_565  = (fmt == kG2d0565);
     /* G2D scissor only: the emitter programs it to the rect itself; the VGV1
        band scissor belongs to the VG rasterizer path and may be stale here. */
@@ -101,16 +103,16 @@ void Imx51Gpu2dDirect2d::Copy(const uint32_t (&regs)[0x100], uint32_t sxy) {
     const uint32_t cfg0 = regs[0x1], cfg1 = regs[0x3];
     if (((cfg0 >> 12) & 0xFu) != kG2d8888)  /* copy dest G2D_8888 only (565 dest copy not modeled) */
         Halt(regs, "SXY copy dest format (not G2D_8888)", 0x1u, cfg0);
-    if (((cfg1 >> 12) & 0xFu) != 7u || (cfg1 >> 16))  /* src G2D_8888, no swap/tile/srgb */
+    if (((cfg1 >> 12) & 0xFu) != 7u || (cfg1 & 0xFF7F0000u))  /* src G2D_8888, no swap/tile/srgb */
         Halt(regs, "SXY copy source format (not linear G2D_8888)", 0x3u, cfg1);
     if (regs[0x2] == 0u)
         Halt(regs, "SXY copy source BASE1 null bind", 0x2u, 0);
     const uint32_t xy = regs[kXy], wh = regs[kWh];
     Gpu2dCopySpec c{};
     c.dst_pa        = regs[0x0];
-    c.dst_stride_px = (cfg0 & 0xFFFu) + 1u;
+    c.dst_stride_dw = imx51_g2d_regfile::StrideWords(cfg0);
     c.src_pa        = regs[0x2];
-    c.src_stride_px = (cfg1 & 0xFFFu) + 1u;
+    c.src_stride_dw = imx51_g2d_regfile::StrideWords(cfg1);
     const uint32_t gsx = regs[0x8], gsy = regs[0x9];  /* dest G2D scissor (inclusive) */
     c.clip_l = static_cast<int32_t>(gsx & 0x7FFu);
     c.clip_r = static_cast<int32_t>((gsx >> 11) & 0x7FFu);
@@ -138,16 +140,16 @@ void Imx51Gpu2dDirect2d::CopyRect(const Gpu2dCopySpec& c) {
             const int32_t dx = c.dst_x + col;
             if (dx < c.clip_l || dx > c.clip_r) continue;
             const int32_t sx = c.src_x + col;
-            const uint32_t spa = c.src_pa + (static_cast<uint32_t>(sy) * c.src_stride_px
-                                             + static_cast<uint32_t>(sx)) * 4u;
+            const uint32_t spa = c.src_pa + static_cast<uint32_t>((sy * c.src_stride_dw
+                                                                   + sx) * 4);
             const uint8_t* shp = mem.TryTranslate(spa);
             if (!shp) {
                 LOG(Caution, "[GPU2D-D2D] copy source pixel unbacked pa=0x%08X (x=%d y=%d)\n",
                     spa, sx, sy);
                 CerfFatalExit(CERF_FATAL_RUNTIME_ERROR);
             }
-            const uint32_t dpa = c.dst_pa + (static_cast<uint32_t>(dy) * c.dst_stride_px
-                                             + static_cast<uint32_t>(dx)) * 4u;
+            const uint32_t dpa = c.dst_pa + static_cast<uint32_t>((dy * c.dst_stride_dw
+                                                                   + dx) * 4);
             uint8_t* dhp = mem.TryTranslateWrite(dpa);
             if (!dhp) {
                 LOG(Caution, "[GPU2D-D2D] copy dest pixel unbacked pa=0x%08X (x=%d y=%d)\n",

--- a/cerf/socs/imx51/imx51_gpu2d_image_paint.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_image_paint.cpp
@@ -32,6 +32,10 @@ constexpr uint32_t kInst0Affine = 0x10080632u, kInst1Affine = 0x12098695u;
 constexpr uint32_t kBcfgVal = 0x69u;                      /* ENABLE|OOALPHA|PASSES=1|ALPHAPASSES=1 */
 constexpr uint32_t kProgA0 = 0x065900E0u, kProgC0 = 0x065904E0u;  /* setup: TEMP1=SRC*IMG, TEMP2=SRC.a*IMG */
 constexpr uint32_t kProgA1 = 0x0A85A004u, kProgC1 = 0x0C85A004u;  /* combine: TEMP0=TEMP1+DEST*(1-TEMP2) */
+/* libOpenVG.dll sub_41C6338C (VA 0x41C6338C), captured live from a Ford SYNC 2
+   boot: second legal image-paint program (VG_BLEND_SRC). */
+constexpr uint32_t kProgA0Src = 0x00190320u, kProgC0Src = 0x00190020u;
+constexpr uint32_t kProgA1Src = 0x00852004u, kProgC1Src = 0x00852004u;
 /* TEXCFG minus STRIDE: FORMAT 7 | PREMULTIPLY[23] | TEX2D[28], everything else 0
    (TILED/WRAP/BILIN/SRGB/SWAP*). A BILIN or swapped or non-premult texture would
    sample wrong, so the whole upper word is gated. */
@@ -68,9 +72,12 @@ void Imx51Gpu2dImagePaint::CheckGates(const uint32_t (&regs)[0x100]) const {
         Halt(regs, "CONFIG (not DST-only, SRC1 disabled)", kConfig, regs[kConfig]);
     if (regs[kBcfg] != kBcfgVal)
         Halt(regs, "BLENDERCFG (not the SRC_OVER multi-pass)", kBcfg, regs[kBcfg]);
-    if (regs[kBlendC0] != kProgC0 || regs[kBlendA0] != kProgA0 ||
-        regs[kBlendC0 + 1u] != kProgC1 || regs[kBlendA0 + 1u] != kProgA1)
-        Halt(regs, "blend program (not the captured SRC_OVER)", kBlendC0, regs[kBlendC0]);
+    const bool isSrcOver = regs[kBlendC0] == kProgC0 && regs[kBlendA0] == kProgA0 &&
+        regs[kBlendC0 + 1u] == kProgC1 && regs[kBlendA0 + 1u] == kProgA1;
+    const bool isSrcCopy = regs[kBlendC0] == kProgC0Src && regs[kBlendA0] == kProgA0Src &&
+        regs[kBlendC0 + 1u] == kProgC1Src && regs[kBlendA0 + 1u] == kProgA1Src;
+    if (!isSrcOver && !isSrcCopy)
+        Halt(regs, "blend program (not a captured SRC_OVER/SRC_SRC)", kBlendC0, regs[kBlendC0]);
     if (regs[kAlphaBlend] != 0x4100u)  /* OBS_ENABLE[8] | PREMULTIPLYDST[14] */
         Halt(regs, "ALPHABLEND (not OBS_ENABLE|PREMULTIPLYDST)", kAlphaBlend, regs[kAlphaBlend]);
     if (regs[kRop] != 0x404u)
@@ -133,8 +140,7 @@ uint32_t Imx51Gpu2dImagePaint::BlendMultiPass(const uint32_t (&regs)[0x100],
     if (regs[kBcfg] & (1u << 6)) {  /* OOALPHA: un-premultiply back to straight-alpha */
         const uint32_t a = out >> 24;
         if (a == 0u) {
-            if (out & 0xFFFFFFu)
-                Halt(regs, "OOALPHA divide on zero-alpha nonzero color", kBcfg, out);
+            out = 0u;
         } else if (a != 255u) {
             out = (a << 24) | (UnpremultChannel((out >> 16) & 0xFFu, a) << 16)
                 | (UnpremultChannel((out >> 8) & 0xFFu, a) << 8) | UnpremultChannel(out & 0xFFu, a);

--- a/cerf/socs/imx51/imx51_gpu2d_rasterizer.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_rasterizer.cpp
@@ -117,11 +117,11 @@ uint32_t Imx51Gpu2dRasterizer::BlendPixel(const Gpu2dFillTarget& t, uint32_t src
     return (a << 24) | (r << 16) | (g << 8) | b;
 }
 
-/* gpuaddr==physical (GPU MMU disabled); row byte stride = stride_px 4-byte words,
+/* gpuaddr==physical (GPU MMU disabled); row byte stride = stride_dw 4-byte words,
    pixel size 2B (G2D_0565) or 4B (G2D_8888). An unbacked dest pixel halts. */
 uint8_t* Imx51Gpu2dRasterizer::DestHost(const Gpu2dFillTarget& t, int32_t x, int32_t y) {
-    const uint32_t pa = t.dest_pa + static_cast<uint32_t>(y) * t.stride_px * 4u
-                      + static_cast<uint32_t>(x) * (t.dest_565 ? 2u : 4u);
+    const uint32_t pa = t.dest_pa + static_cast<uint32_t>(y * t.stride_dw * 4)
+                      + static_cast<uint32_t>(x * (t.dest_565 ? 2 : 4));
     uint8_t* hp = emu_.Get<EmulatedMemory>().TryTranslateWrite(pa);
     if (!hp) {
         LOG(Caution, "[GPU2D-RAST] dest pixel unbacked pa=0x%08X (x=%d y=%d)\n", pa, x, y);

--- a/cerf/socs/imx51/imx51_gpu2d_rasterizer.h
+++ b/cerf/socs/imx51/imx51_gpu2d_rasterizer.h
@@ -14,7 +14,7 @@ class Imx51Gpu2dGradwSampler;
    (G2D_BASE0/CFG0/SCISSORX/Y + VGV1_SCISSORX/Y + VGV1_CFG1 + G2D_COLOR). */
 struct Gpu2dFillTarget {
     uint32_t dest_pa;    /* G2D_BASE0 (tile-corner physical; gpuaddr==physical) */
-    uint32_t stride_px;  /* G2D_CFG0.STRIDE + 1, in 4-byte words (== pixels for a 32bpp dest) */
+    int32_t  stride_dw;
     bool     dest_565 = false;  /* G2D_CFG0.FORMAT: false=G2D_8888(7), true=G2D_0565(6) */
     int32_t  clip_l, clip_t, clip_r, clip_b;  /* inclusive px, scissors pre-intersected */
     uint32_t argb;       /* G2D_COLOR, PREMULTIPLIED ARGB8888 (paint setup premultiplies
@@ -38,9 +38,9 @@ struct Gpu2dFillTarget {
    (emitter sub_41C6C448 writes CFG=STRIDE|0x7000), so the copy is byte-identical. */
 struct Gpu2dCopySpec {
     uint32_t dst_pa;         /* G2D_BASE0 (tile-corner physical; gpuaddr==physical) */
-    uint32_t dst_stride_px;  /* G2D_CFG0.STRIDE + 1 */
+    int32_t  dst_stride_dw;
     uint32_t src_pa;         /* G2D_BASE1 */
-    uint32_t src_stride_px;  /* G2D_CFG1.STRIDE + 1 */
+    int32_t  src_stride_dw;
     int32_t  clip_l, clip_t, clip_r, clip_b;  /* inclusive dest G2D scissor */
     int32_t  dst_x, dst_y;   /* G2D_XY dest origin (signed 12-bit) */
     int32_t  src_x, src_y;   /* G2D_SXY source origin (unsigned 11-bit) */
@@ -87,7 +87,7 @@ public:
 
 private:
     [[noreturn]] void HaltBlend(const char* why, uint32_t prog) const;
-    /* Byte address of dest pixel (x,y) per t.dest_565 (row stride = stride_px
+    /* Byte address of dest pixel (x,y) per t.dest_565 (row stride = stride_dw
        4-byte words); FATAL if unbacked. */
     uint8_t* DestHost(const Gpu2dFillTarget& t, int32_t x, int32_t y);
     uint32_t LoadDest(const Gpu2dFillTarget& t, int32_t x, int32_t y);   /* dest as ARGB8888 */

--- a/cerf/socs/imx51/imx51_gpu2d_regfile.h
+++ b/cerf/socs/imx51/imx51_gpu2d_regfile.h
@@ -16,6 +16,14 @@ inline float RegF(const uint32_t (&regs)[0x100], uint32_t reg) {
     return f;
 }
 
+/* G2D_CFG0/1 STRIDE[11:0]+STRIDESIGN[23]: one 13-bit two's-complement of
+   (row 4-byte words - 1). sync_2 libOpenVG.dll FUN_41c6ae4c 0x41C6AE4C emits the
+   negative form with G2D_BASE advanced to the surface's last row. */
+inline int32_t StrideWords(uint32_t cfg) {
+    const uint32_t f13 = (cfg & 0xFFFu) | ((cfg >> 11) & 0x1000u);
+    return (static_cast<int32_t>(f13 << 19) >> 19) + 1;
+}
+
 /* 2^VGV2_MODE.EXPONENTADD[23:18] (signed 6-bit): the XF affine outputs subpixels
    that the driver premultiplies by this power of two (fill engine sub_41C63970). */
 inline float DeviceScale(const uint32_t (&regs)[0x100]) {

--- a/cerf/socs/imx51/imx51_gpu2d_vg_fill.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_vg_fill.cpp
@@ -91,13 +91,14 @@ void Imx51Gpu2dVgFill::Flush(const uint32_t (&regs)[0x100], bool bbox_live) {
     const uint32_t cfg0 = regs[0x1];
     if (((cfg0 >> 12) & 0xFu) != 7u)           /* G2D_CFG0.FORMAT: G2D_8888 only */
         Halt(regs, "dest format (not G2D_8888)", 0x1u, cfg0);
-    if (cfg0 >> 16)                            /* TILED/SRGB/swap/stridesign */
+    if (cfg0 & 0xFF7F0000u)                    /* TILED[16]/SRGB[17]/SWAP fields;
+                                                  STRIDESIGN[23] belongs to the stride */
         Halt(regs, "dest tiled/swapped/srgb (not modeled)", 0x1u, cfg0);
     if (regs[0x0] == 0u)                       /* null dest bind */
         Halt(regs, "dest BASE0 null bind", 0x0u, 0);
     Gpu2dFillTarget t{};
     t.dest_pa   = regs[0x0];
-    t.stride_px = (cfg0 & 0xFFFu) + 1u;
+    t.stride_dw = imx51_g2d_regfile::StrideWords(cfg0);
     /* sync_2 libOpenVG.dll 0x41C5B468 tile loop: VGV1_SCISSORX/Y (0x24/0x25) hold the
        tile clamped in a grid anchored at 0, VGV1_TILEOFS (0x22) that tile's grid origin
        plus the path-bbox sub-tile remainder, and G2D_SCISSORX/Y (0x8/0x9) the device


### PR DESCRIPTION
Three fixes that unblock the Ford SYNC 2 OpenVG path. First, `G2D_CFG0/1` carries a 13-bit two's-complement stride, `STRIDE[11:0]` plus `STRIDESIGN[23]`, not a plain 12-bit unsigned field. `libOpenVG.dll` (`FUN_41c6ae4c`) emits the negative form with `G2D_BASE` advanced to the surface's last row for bottom-up targets, which the old upper-word gate rejected outright; a live CFG1 of `0x00807CDF` decodes to `-800` words under the correct reading and to a meaningless `3296` under the old one. `StrideWords()` in [imx51_gpu2d_regfile.h](cerf/socs/imx51/imx51_gpu2d_regfile.h) now decodes both halves, the fill/copy targets carry it as a signed `int32_t`, and the tile/swap/sRGB gates mask bit 23 out instead of halting on it. Second, image paint accepts a second blend program captured live from a SYNC 2 boot (`sub_41C6338C`, `VG_BLEND_SRC`) alongside the existing `SRC_OVER`, and the `BLENDERCFG.OOALPHA` un-premultiply now yields zero for a fully transparent pixel rather than treating `a == 0` as a corruption halt. Third, the UI drives a third `G2D_INPUT` value for plain rect fills, `0x1B` (`libOpenVG.dll` VA `0x41C718B8`), with `GRADIENT` and `BLENDERCFG.ENABLE` both off — it now routes to `Direct2d::Fill` like the known `0x01`/`0x09`.

All three gates fire on the same interaction: tapping from Home into the Climate screen. On `main` that tap halts 0.1s later on the blend program (`0x00190020`); with only the first two commits it halts on the unmodeled `G2D_INPUT = 0x1B`. With the branch complete the tap transitions and renders, and the run continues with no cautions.

**Proof**

<!-- image -->
<img width="800" height="480" alt="live_state" src="https://github.com/user-attachments/assets/dd9899bb-08ff-40bb-92e6-1ce1d9b93d01" />