### PR TITLE
Model GPU2D constant blends for the navigation keyboard

### DIFF
--- a/cerf/socs/imx51/imx51_gpu2d_blend.h
+++ b/cerf/socs/imx51/imx51_gpu2d_blend.h
@@ -28,6 +28,49 @@ constexpr uint32_t kDstIgnore = 0u;
 /* One 8-bit channel product with the HW's round-to-nearest /255. */
 constexpr uint32_t Mul(uint32_t a, uint32_t b) { return (a * b + 127u) / 255u; }
 
+/* NXP Z160 REG_G2D_BLEND_A0/C0: CONST selects G2D_CONST[SRC] instead
+   of a pixel input. sync_2 libOpenVG.dll 0x41C57D14/0x41C57F78 encode
+   this same selector, followed by alpha replication and inversion. */
+inline uint32_t Operand(uint32_t prog, uint32_t i, uint32_t shift,
+                        const uint32_t* inputs, const uint32_t* constants) {
+    const uint32_t pixel = Const(prog, i) ? constants[Src(prog, i)] : inputs[Src(prog, i)];
+    const uint32_t v = (pixel >> (Ar(prog, i) ? 24u : shift)) & 0xFFu;
+    return Inv(prog, i) ? 255u - v : v;
+}
+
+/* ADD programs, validated by the dispatchers. Both pipes read the previous
+   pass's TEMP values: sync_2 libOpenVG.dll 0x41C58230 writes TEMP1 RGBA,
+   and 0x41C60610 emits a following color pass that reads TEMP1.a. */
+inline uint32_t AddProgram(const uint32_t* alpha, uint32_t alpha_passes,
+                           const uint32_t* color, uint32_t color_passes,
+                           const uint32_t* constants, uint32_t src, uint32_t dst) {
+    uint32_t temp[3] = {};
+    for (uint32_t p = 0; p < color_passes || p < alpha_passes; ++p) {
+        const uint32_t inputs[] = {0u, src, dst, 0xFFFFFFFFu, temp[0], temp[1], temp[2]};
+        auto run = [&](uint32_t prog, uint32_t shift) {
+            const uint32_t p1 = Mul(Operand(prog, 0, shift, inputs, constants),
+                                     Operand(prog, 1, shift, inputs, constants));
+            const uint32_t p2 = Mul(Operand(prog, 2, shift, inputs, constants),
+                                     Operand(prog, 3, shift, inputs, constants));
+            auto put = [&](uint32_t d, uint32_t value) {
+                if (d == kDstIgnore) return;
+                if (value > 255u) value = 255u;
+                temp[d - 1u] = (temp[d - 1u] & ~(0xFFu << shift)) | (value << shift);
+            };
+            put(Dst(prog, 0), p1 + p2);
+            put(Dst(prog, 1), p1);
+            put(Dst(prog, 2), p2);
+        };
+        if (p < color_passes) {
+            run(color[p], 16u);
+            run(color[p], 8u);
+            run(color[p], 0u);
+        }
+        if (p < alpha_passes) run(alpha[p], 24u);
+    }
+    return temp[0];
+}
+
 /* Per-channel product of two PREMULTIPLIED ARGB8888 pixels (all 4 channels incl.
    alpha). texel(premult)_C * COLOR(premult)_C == imageA*paintA*Cimage*Cpaint = the
    OpenVG image-mode premultiplied source (openvg_spec.pdf VG_DRAW_IMAGE_STENCIL/

--- a/cerf/socs/imx51/imx51_gpu2d_command_engine.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_command_engine.cpp
@@ -112,8 +112,11 @@ bool Imx51Gpu2dCommandEngine::IsConsumedConfigReg(uint32_t reg) {
         case 0x11u:  /* G2D_BLENDERCFG                - FlushPath blend */
         case 0x14u:  /* G2D_BLEND_A0                  - FlushPath t.prog_a / ImagePaint setup */
         case 0x18u:  /* G2D_BLEND_C0                  - FlushPath t.prog_c / ImagePaint setup */
-        case 0x15u:  /* G2D_BLEND_A1                  - ImagePaint multi-pass combine (alpha) */
-        case 0x19u:  /* G2D_BLEND_C1                  - ImagePaint multi-pass combine (color) */
+        case 0x15u:  /* G2D_BLEND_A1                  - VG fill / ImagePaint second alpha pass */
+        case 0x19u:  /* G2D_BLEND_C1                  - VG fill / ImagePaint second color pass */
+        case 0xB0u: case 0xB1u: case 0xB2u: case 0xB3u:
+        case 0xB4u: case 0xB5u: case 0xB6u: case 0xB7u:
+                     /* G2D_CONST0-7 ARGB blend operands - VG fill / ImagePaint */
         case 0x24u:  /* VGV1_SCISSORX                 - FlushPath clip */
         case 0x25u:  /* VGV1_SCISSORY                 - FlushPath clip */
         case kAddrVgv1Tileofs:  /* 0x22 VGV1_TILEOFS sub-tile offset - EmitPoint */
@@ -168,7 +171,7 @@ void Imx51Gpu2dCommandEngine::StoreReg(uint32_t reg, uint32_t data) {
         case 0x1Cu: case 0x1Du: case 0x1Eu: case 0x1Fu:
             /* BLEND_A2/A3 + BLEND_C2-C7 = the 3rd+ blend-program passes
                (vgregs_z160.h:69-70,73-78); the composite gates BCFG=0x69 (2 passes:
-               A0/A1/C0/C1) and VG-fill FATALs any multi-pass, so these higher passes
+               A0/A1/C0/C1) and VG-fill allows at most two passes, so these higher passes
                are never read - proven-inert, stored. */
             vg_regs_[reg] = data;
             return;

--- a/cerf/socs/imx51/imx51_gpu2d_image_paint.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_image_paint.cpp
@@ -97,46 +97,10 @@ uint32_t Imx51Gpu2dImagePaint::BlendMultiPass(const uint32_t (&regs)[0x100],
                                               uint32_t src, uint32_t dst) const {
     /* ALPHABLEND.PREMULTIPLYDST (gated set): premultiply the straight-alpha dest. */
     const uint32_t dstop = PremultArgb(dst);
-    const uint32_t image = 0xFFFFFFFFu;  /* SRC1=0: second texture disabled -> identity */
-    uint32_t temp[3] = {0u, 0u, 0u};
-
-    auto operand = [&](uint32_t prog, uint32_t i, uint32_t shift) -> uint32_t {
-        const uint32_t sh = Ar(prog, i) ? 24u : shift;
-        uint32_t v;
-        switch (Src(prog, i)) {
-            case kSrcZero:   v = 0u; break;
-            case kSrcSource: v = (src >> sh) & 0xFFu; break;
-            case kSrcDest:   v = (dstop >> sh) & 0xFFu; break;
-            case kSrcImage:  v = (image >> sh) & 0xFFu; break;
-            case kSrcTemp0:  v = (temp[0] >> sh) & 0xFFu; break;
-            case kSrcTemp1:  v = (temp[1] >> sh) & 0xFFu; break;
-            default:         v = (temp[2] >> sh) & 0xFFu; break;  /* TEMP2 (SRC 7 gated out) */
-        }
-        return Inv(prog, i) ? 255u - v : v;
-    };
-    auto run = [&](uint32_t prog, uint32_t shift) {
-        const uint32_t p1 = Mul(operand(prog, 0, shift), operand(prog, 1, shift));
-        const uint32_t p2 = Mul(operand(prog, 2, shift), operand(prog, 3, shift));
-        auto put = [&](uint32_t d, uint32_t val) {
-            if (d == kDstIgnore) return;
-            temp[d - 1u] = (temp[d - 1u] & ~(0xFFu << shift)) | (std::min(val, 255u) << shift);
-        };
-        put(Dst(prog, 0), p1 + p2);  /* DST_A <- P1+P2 */
-        put(Dst(prog, 1), p1);       /* DST_B <- P1 */
-        put(Dst(prog, 2), p2);       /* DST_C <- P2 */
-    };
-
     const uint32_t passes = (regs[kBcfg] & 7u) + 1u;           /* PASSES[2:0] + 1 color passes */
     const uint32_t apasses = ((regs[kBcfg] >> 3) & 3u) + 1u;   /* ALPHAPASSES[4:3] + 1 alpha passes */
-    for (uint32_t p = 0; p < passes; ++p) {
-        run(regs[kBlendC0 + p], 16u);
-        run(regs[kBlendC0 + p], 8u);
-        run(regs[kBlendC0 + p], 0u);
-    }
-    for (uint32_t p = 0; p < apasses; ++p)
-        run(regs[kBlendA0 + p], 24u);
-
-    uint32_t out = temp[0];  /* output pixel = TEMP0 */
+    uint32_t out = AddProgram(regs + kBlendA0, apasses, regs + kBlendC0, passes,
+                              regs + 0xB0, src, dstop);
     if (regs[kBcfg] & (1u << 6)) {  /* OOALPHA: un-premultiply back to straight-alpha */
         const uint32_t a = out >> 24;
         if (a == 0u) {

--- a/cerf/socs/imx51/imx51_gpu2d_rasterizer.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_rasterizer.cpp
@@ -49,11 +49,11 @@ using namespace imx51_g2d_blend;
 
 bool Imx51Gpu2dRasterizer::BlendProgRefsDest(uint32_t prog) {
     for (uint32_t i = 0; i < 4u; ++i)
-        if (Src(prog, i) == kSrcDest) return true;
+        if (!Const(prog, i) && Src(prog, i) == kSrcDest) return true;
     return false;
 }
 
-/* Per-path gate on a single blend micro-op: only ADD over the ZERO/SOURCE/DEST
+/* Per-path gate on a single blend micro-op: ADD over constants or ZERO/SOURCE/DEST
    selectors with the single-pass TEMP0 output is modeled; every other decoded
    field value halts. */
 void Imx51Gpu2dRasterizer::ValidateBlendProg(uint32_t prog) const {
@@ -62,9 +62,7 @@ void Imx51Gpu2dRasterizer::ValidateBlendProg(uint32_t prog) const {
     if (Dst(prog, 0) != 1u || Dst(prog, 1) != 0u || Dst(prog, 2) != 0u)
         HaltBlend("blend multi-TEMP routing", prog);
     for (uint32_t i = 0; i < 4u; ++i) {
-        if (Const(prog, i))
-            HaltBlend("blend CONST operand", prog);
-        if (Src(prog, i) > kSrcDest)  /* IMAGE/TEMP0-2 */
+        if (!Const(prog, i) && Src(prog, i) > kSrcDest)  /* IMAGE/TEMP0-2 */
             HaltBlend("blend IMAGE/TEMP operand", prog);
     }
 }
@@ -88,22 +86,28 @@ uint32_t Imx51Gpu2dRasterizer::BlendPixel(const Gpu2dFillTarget& t, uint32_t src
     }
     if (t.premult_dst)  /* straight-alpha dest: premultiply the DEST operand */
         dst = PremultArgb(dst);
+    const uint32_t inputs[] = {0u, src, dst};
     auto chan = [&](uint32_t prog, uint32_t shift) -> uint32_t {
         auto operand = [&](uint32_t i) -> uint32_t {
-            const uint32_t sh = Ar(prog, i) ? 24u : shift;
-            uint32_t v = 0;
-            switch (Src(prog, i)) {
-                case kSrcZero:   v = 0; break;
-                case kSrcSource: v = (src >> sh) & 0xFFu; break;
-                default:         v = (dst >> sh) & 0xFFu; break;  /* DEST (validated) */
-            }
-            return Inv(prog, i) ? 255u - v : v;
+            return Operand(prog, i, shift, inputs, t.blend_const);
         };
         const uint32_t sum = Mul(operand(0), operand(1)) + Mul(operand(2), operand(3));
         return std::min(sum, 255u);
     };
-    const uint32_t a = chan(t.prog_a, 24u);
-    uint32_t r = chan(t.prog_c, 16u), g = chan(t.prog_c, 8u), b = chan(t.prog_c, 0u);
+    uint32_t a, r, g, b;
+    if (t.color_transform) {
+        const uint32_t alpha[] = {t.prog_a, t.prog_a1}, color[] = {t.prog_c, t.prog_c1};
+        const uint32_t out = AddProgram(alpha, 2u, color, 2u, t.blend_const, src, dst);
+        a = out >> 24;
+        r = (out >> 16) & 0xFFu;
+        g = (out >> 8) & 0xFFu;
+        b = out & 0xFFu;
+    } else {
+        a = chan(t.prog_a, 24u);
+        r = chan(t.prog_c, 16u);
+        g = chan(t.prog_c, 8u);
+        b = chan(t.prog_c, 0u);
+    }
     if (t.oo_alpha && a != 255u) {  /* one-over-alpha: un-premultiply the result */
         if (a == 0u) {
             if (r | g | b)
@@ -205,9 +209,11 @@ void Imx51Gpu2dRasterizer::Flush(const Gpu2dFillTarget& t) {
     uint32_t const_px  = t.argb;
     bool     per_pixel = t.paint != nullptr;
     if (t.blend) {
-        ValidateBlendProg(t.prog_a);
-        ValidateBlendProg(t.prog_c);
-        per_pixel = per_pixel || BlendProgRefsDest(t.prog_a) || BlendProgRefsDest(t.prog_c);
+        if (!t.color_transform) {
+            ValidateBlendProg(t.prog_a);
+            ValidateBlendProg(t.prog_c);
+        }
+        per_pixel = per_pixel || t.color_transform || BlendProgRefsDest(t.prog_a) || BlendProgRefsDest(t.prog_c);
         if (!per_pixel) const_px = BlendPixel(t, t.argb, 0u, 1.0f);
     }
 

--- a/cerf/socs/imx51/imx51_gpu2d_rasterizer.h
+++ b/cerf/socs/imx51/imx51_gpu2d_rasterizer.h
@@ -20,13 +20,16 @@ struct Gpu2dFillTarget {
     uint32_t argb;       /* G2D_COLOR, PREMULTIPLIED ARGB8888 (paint setup premultiplies
                             via libOpenVG sub_41C69F40: ch = ch*A/255) */
     bool     even_odd;   /* VGV1_CFG1.WINDRULE: 1=even-odd, 0=nonzero */
-    bool     blend;      /* G2D_BLENDERCFG.ENABLE (single-pass only; multi-pass gated) */
+    bool     blend;      /* G2D_BLENDERCFG.ENABLE */
     bool     oo_alpha;   /* G2D_BLENDERCFG.OOALPHA: un-premultiply the blend result */
     bool     premult_dst; /* G2D_ALPHABLEND.PREMULTIPLYDST: premultiply the DEST operand
                              (paired with OOALPHA by sub_41C60610 for straight-alpha
                              surfaces, fmt==12427) */
     uint32_t prog_a;     /* G2D_BLEND_A0 alpha-pipe micro-op */
     uint32_t prog_c;     /* G2D_BLEND_C0 color-pipe micro-op */
+    bool     color_transform = false;  /* CONST0/1 transform followed by SRC_OVER */
+    uint32_t prog_a1 = 0, prog_c1 = 0;
+    uint32_t blend_const[8] = {};      /* G2D_CONST0-7, selected by CONST/SRC */
     /* When set, the per-pixel SOURCE is the GRADW texel sample at (x,y) instead
        of the solid argb (VG-fill gradient paint); null = solid/copy fill. */
     const Gpu2dGradwPaint* paint = nullptr;

--- a/cerf/socs/imx51/imx51_gpu2d_stroker.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_stroker.cpp
@@ -165,9 +165,11 @@ void Imx51Gpu2dStroker::Stroke(const Gpu2dFillTarget& t, float radius_raw,
     uint32_t const_px = t.argb;
     bool per_pixel = false;
     if (t.blend) {
-        rast.ValidateBlendProg(t.prog_a);
-        rast.ValidateBlendProg(t.prog_c);
-        per_pixel = Imx51Gpu2dRasterizer::BlendProgRefsDest(t.prog_a) ||
+        if (!t.color_transform) {
+            rast.ValidateBlendProg(t.prog_a);
+            rast.ValidateBlendProg(t.prog_c);
+        }
+        per_pixel = t.color_transform || Imx51Gpu2dRasterizer::BlendProgRefsDest(t.prog_a) ||
                     Imx51Gpu2dRasterizer::BlendProgRefsDest(t.prog_c);
         if (!per_pixel) const_px = rast.BlendPixel(t, t.argb, 0u, 1.0f);
     }

--- a/cerf/socs/imx51/imx51_gpu2d_vg_fill.cpp
+++ b/cerf/socs/imx51/imx51_gpu2d_vg_fill.cpp
@@ -62,8 +62,13 @@ void Imx51Gpu2dVgFill::Flush(const uint32_t (&regs)[0x100], bool bbox_live) {
             Halt(regs, "GRADW TEXBASE null bind", 0xD3u, 0);
     }
     const uint32_t bcfg = regs[0x11];          /* G2D_BLENDERCFG (vgregs_z160.h:356-363) */
-    if (bcfg & (1u << 5)) {                    /* ENABLE: single-pass A0/C0 program only */
-        if (bcfg & 0x1Fu)                      /* PASSES[2:0] / ALPHAPASSES[4:3] */
+    /* sync_2 libOpenVG.dll 0x41C58230 / 0x41C60610: TEMP1=SOURCE*CONST0+CONST1,
+       then TEMP0=TEMP1+DEST*(1-TEMP1.a). City Center keyboard color transform. */
+    const bool color_transform = (bcfg & 0x1Fu) == 9u &&
+        regs[0x14] == 0x60418008u && regs[0x18] == 0x60418008u &&
+        regs[0x15] == 0x0A85A004u && regs[0x19] == 0x0A85A804u;
+    if (bcfg & (1u << 5)) {                    /* ENABLE */
+        if ((bcfg & 0x1Fu) && !color_transform) /* PASSES[2:0] / ALPHAPASSES[4:3] */
             Halt(regs, "G2D multi-pass blend (not modeled)", 0x11u, bcfg);
         if (bcfg & 0x180u)                     /* OBS_DIVALPHA[7] / NOMASK[8] */
             Halt(regs, "G2D blender DIVALPHA/NOMASK (not modeled)", 0x11u, bcfg);
@@ -134,6 +139,10 @@ void Imx51Gpu2dVgFill::Flush(const uint32_t (&regs)[0x100], bool bbox_live) {
     t.premult_dst = (regs[0xC] & 0x4000u) != 0u;  /* ALPHABLEND.PREMULTIPLYDST */
     t.prog_a      = regs[0x14];                /* G2D_BLEND_A0 */
     t.prog_c      = regs[0x18];                /* G2D_BLEND_C0 */
+    t.color_transform = color_transform;
+    t.prog_a1 = regs[0x15];
+    t.prog_c1 = regs[0x19];
+    std::copy_n(regs + 0xB0, 8, t.blend_const);
     /* GRADW gradient paint: per-pixel SOURCE = the fmt7 ramp texel at the (OUTX,OUTY)
        the ISA program (INST0..INST(INSTRUCTIONS)) computes from CONST0-C11. */
     Gpu2dGradwPaint pg{};


### PR DESCRIPTION
Support the constant blend operands and two-pass color transform used by the SYNC 2 Navigation Destination keyboard. Share blend operand evaluation across image paint, fills and strokes, and carry the constant registers through the fill target. VG fills accept the recognized constant-color transform followed by source-over blending; other unsupported multi-pass programs remain rejected.